### PR TITLE
github action 스크립트 추가

### DIFF
--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -1,0 +1,48 @@
+name: NomadCafe
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - feature/cicd
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.aws_access_key }}
+        aws-secret-access-key: ${{ secrets.aws_secret_key }}
+        aws-region: ap-northeast-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: nomad-cafe
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION -f Dockerfile .
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+    - name: Create Release
+      id: create-release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # github 내부에서 적용되는 시크릿 변수이기 때문에 별도로 만들지 않아도 됨
+      with:
+        tag_name: v${{ steps.build-init.outputs.version }}
+        release_name: Release v${{ steps.build-init.outputs.version }}
+        body: |
+          ${{ steps.build-init.outputs.git-commit-msg }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-        uses: actions/checkout@v1
+      uses: actions/checkout@v1
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -29,8 +29,8 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
       run: |
         cd $GITHUB_WORKSPACE
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION -f Dockerfile .
-        docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
@@ -39,9 +39,10 @@ jobs:
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # github 내부에서 적용되는 시크릿 변수이기 때문에 별도로 만들지 않아도 됨
+        IMAGE_TAG: ${{ github.sha }}
       with:
-        tag_name: v${{ steps.build-init.outputs.version }}
-        release_name: Release v${{ steps.build-init.outputs.version }}
+        tag_name: v$IMAGE_TAG
+        release_name: Release v$IMAGE_TAG
         body: |
           ${{ steps.build-init.outputs.git-commit-msg }}
         draft: false

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -34,7 +34,6 @@ jobs:
         cd $GITHUB_WORKSPACE
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile_with_apm .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-#        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 #    - name: Create Release

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -31,9 +31,7 @@ jobs:
         ECR_REPOSITORY: nomad-cafe
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        ls -l
         cd $GITHUB_WORKSPACE
-        ls -l
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -29,7 +29,7 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
       run: |
         cd $GITHUB_WORKSPACE
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -10,6 +10,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+        uses: actions/checkout@v1
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -28,7 +28,9 @@ jobs:
         ECR_REPOSITORY: nomad-cafe
         IMAGE_TAG: ${{ github.sha }}
       run: |
+        ls -l
         cd $GITHUB_WORKSPACE
+        ls -l
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -34,7 +34,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+#        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 #    - name: Create Release

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -32,7 +32,7 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
       run: |
         cd $GITHUB_WORKSPACE
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile_with_apm .
         docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
 #        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -41,7 +41,7 @@ jobs:
       id: create-release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # github 내부에서 적용되는 시크릿 변수이기 때문에 별도로 만들지 않아도 됨
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         IMAGE_TAG: ${{ github.sha }}
       with:
         tag_name: v$IMAGE_TAG

--- a/.github/workflows/nomad-cafe.yml
+++ b/.github/workflows/nomad-cafe.yml
@@ -37,16 +37,16 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-    - name: Create Release
-      id: create-release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        IMAGE_TAG: ${{ github.sha }}
-      with:
-        tag_name: v$IMAGE_TAG
-        release_name: Release v$IMAGE_TAG
-        body: |
-          ${{ steps.build-init.outputs.git-commit-msg }}
-        draft: false
-        prerelease: false
+#    - name: Create Release
+#      id: create-release
+#      uses: actions/create-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        IMAGE_TAG: ${{ github.sha }}
+#      with:
+#        tag_name: v$IMAGE_TAG
+#        release_name: Release v$IMAGE_TAG
+#        body: |
+#          ${{ steps.build-init.outputs.git-commit-msg }}
+#        draft: false
+#        prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ static_root/
 *.sqlite3
 *.pyc
 .secret
+
+# Jetbrain
+.idea

--- a/Dockerfile_with_apm
+++ b/Dockerfile_with_apm
@@ -1,0 +1,13 @@
+FROM python:3.7
+
+ENV PYTHONUNBUFFERED 1
+ENV NEW_RELIC_CONFIG_FILE=newrelic.ini
+
+ADD . /wwwroot/
+WORKDIR /wwwroot
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+RUN pip install newrelic
+
+CMD newrelic-admin run-program gunicorn was.wsgi:application --bind 0.0.0.0:8000

--- a/docker-compose-with-apm.yml
+++ b/docker-compose-with-apm.yml
@@ -1,0 +1,20 @@
+version : '3.5'
+services:
+    nginx:
+        image: nginx:latest
+        ports:
+            - "80:80"
+        volumes:
+            - .:/wwwroot
+            - ./config/nginx:/etc/nginx/conf.d
+        depends_on:
+            - web
+    web:
+        build:
+            context: .
+            dockerfile: Dockerfile_with_apm
+        environment:
+            - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
+        command: newrelic-admin run-program gunicorn was.wsgi:application --bind 0.0.0.0:8000
+        expose:
+            - "8000"

--- a/docker-compose-with-apm.yml
+++ b/docker-compose-with-apm.yml
@@ -10,11 +10,13 @@ services:
         depends_on:
             - web
     web:
-        build:
-            context: .
-            dockerfile: Dockerfile_with_apm
+        image: 992189553983.dkr.ecr.ap-northeast-2.amazonaws.com/nomad-cafe:latest
         environment:
             - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
-        command: newrelic-admin run-program gunicorn was.wsgi:application --bind 0.0.0.0:8000
+            - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
+            - DJANGO_DEBUG=${DJANGO_DEBUG}
+            - DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS}
+            - DB_NAME=${DB_NAME}
+            - DB_HOST=${DB_HOST}
         expose:
             - "8000"

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -27,7 +27,7 @@
 # You must specify the license key associated with your New
 # Relic account. This key binds the Python Agent's data to your
 # account in the New Relic service.
-license_key = changeme
+# license_key = changeme
 
 # The application name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -1,0 +1,210 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+license_key = changeme
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+app_name = nomad-cafe
+
+# New Relic offers distributed tracing for monitoring and analyzing modern
+# distributed systems.Enable distributed tracing.
+distributed_tracing.enabled = true
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = nomad-cafe (Staging)
+monitor_mode = true
+
+[newrelic:production]
+monitor_mode = true
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## CI/CD 절차
- 웹 서버가 실행되고 있는 EC2 인스턴스는 외부 접근이 불가능한 Private 서브넷에 생성되어 있다.
- 배포 자동화를 위해서는 외부에서 대상 EC2 인스턴스로 SSH 접속이 가능해야 한다.
- Github Action으로 배포 할 경우 Github Action 스크립트가 실행되는 Github 쪽 서버의 ACL이 허용되어 있어야 하지만 Github Action이 실행되는 서버는 불특정 다수의 Ip를 사용한다.
- ECR로 이미지만 push되면 해당 이벤트에 의해 Github과는 별개로 배포가 진행되도록 구성하기 위해 AWS EventBridge를 활용한다.
- 대안으로 Elastic beanstalk 사용하면 빌드 트리거만 하면 되어서 더 심플하게 구성 가능할 듯

![스크린샷 2020-08-09 오후 7 57 06](https://user-images.githubusercontent.com/15684652/89732122-ac0a0780-da87-11ea-8502-2fcd5919e984.png)

## AWS EventBridge와 Lambda 관련 내용
- 참고 : https://github.com/depromeet/nomad-cafe-subsystem/pull/6